### PR TITLE
Merging of colorpicker implementations. Code cleanup. (See issue #3)

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,13 +3,6 @@
 The ColorPicker Module adds a color-picker input field to the SilverStripe CMS. It makes use of the ColorPicker jQuery
 Plugin.
 
-## History
-
-This module was taken from http://bummzack.ch/colorpicker/ and is the work of Roman Schmid, AKA banal. There is more
-infomration regarding the history of this module at http://www.silverstripe.org/customising-the-cms/show/6114
-
-Dimension27 have created a git repo for it so as it can easily be reused in silverstripe projects.
-
 ## Installation
 
  * Extract all files into the 'colorpicker' folder under your Silverstripe root, or install using composer
@@ -20,13 +13,29 @@ composer require "tractorcow/silverstripe-colorpicker" "3.0.*@dev"
 
 ## Usage
 
-Adding a ColorField to your Page is as simple as this:
+Here's how you define a DB field to be a color:
 
 ```php
-// place this inside your getCMSFields method
-$fields->addFieldToTab(
-    'Root.Main', 
-    new ColorField('BgColor', 'Background Color')
-); 
+private static $db = array(
+    'BgColor' => 'Color'
+);
+```
+    
+That's all... scaffolding will take care of creating the appropriate form-field.
+
+If you use `getCMSFields` to create your fields yourself, you might want to do something like this:
+
+```php
+public function getCMSFields()
+{
+    $fields = parent::getCMSFields();
+
+    $fields->addFieldToTab(
+    	'Root.Main', 
+    	new ColorField('BgColor', 'Background color')
+    );
+
+    return $fields;
+}
 ```
 

--- a/_config.php
+++ b/_config.php
@@ -1,7 +1,12 @@
 <?php
 /**
- * This is the config file of the SilverStripe ColorPicker Form-Element
- * @author Roman Schmid, AKA banal
+ * ColorPicker Form-Field for SilverStripe 3.x
+ * @author Roman Schmid, AKA bummzack
  * 
  * ColorPicker jQuery widget/plugin by http://www.eyecon.ro/colorpicker/
  */
+
+// define colorpicker dir so that the installation doesn't need a fixed directory name
+if(!defined('COLORPICKER_DIR')){
+	define('COLORPICKER_DIR', basename(__DIR__));
+}

--- a/code/Color.php
+++ b/code/Color.php
@@ -1,0 +1,221 @@
+<?php
+/**
+ * Color field-type
+ * @author bummzack
+ */
+class Color extends Varchar
+{
+	private static $casting = array(
+		'Luminance' => 'Float',
+		'AlteredColorHSV' => 'Color'
+	);
+
+	/**
+	 * Helper function to convert RGB to HSV
+	 * @param int $R red channel, 0-255
+	 * @param int $G green channel, 0-255
+	 * @param int $B blue channel, 0-255
+	 * @return array containing 3 values, H,S,V 0-1
+	*/
+	public static function RGB_TO_HSV ($R, $G, $B)  // RGB Values:Number 0-255
+	{
+		$HSV = array();
+
+		$var_R = ($R / 255);
+		$var_G = ($G / 255);
+		$var_B = ($B / 255);
+
+		$var_Min = min($var_R, $var_G, $var_B);
+		$var_Max = max($var_R, $var_G, $var_B);
+		$del_Max = $var_Max - $var_Min;
+
+		$V = $var_Max;
+
+		if ($del_Max == 0)
+		{
+			$H = 0;
+			$S = 0;
+		}
+		else
+		{
+			$S = $del_Max / $var_Max;
+
+			$del_R = ((($var_Max - $var_R) / 6) + ($del_Max / 2)) / $del_Max;
+			$del_G = ((($var_Max - $var_G) / 6) + ($del_Max / 2)) / $del_Max;
+			$del_B = ((($var_Max - $var_B) / 6) + ($del_Max / 2)) / $del_Max;
+
+			if      ($var_R == $var_Max) $H = $del_B - $del_G;
+			else if ($var_G == $var_Max) $H = ( 1 / 3 ) + $del_R - $del_B;
+			else if ($var_B == $var_Max) $H = ( 2 / 3 ) + $del_G - $del_R;
+
+			if ($H<0) $H++;
+			if ($H>1) $H--;
+		}
+
+		$HSV[] = $H;
+		$HSV[] = $S;
+		$HSV[] = $V;
+
+		return $HSV;
+	}
+
+	/**
+	 * Helper function to convert HSV to RGB
+	 * @param float $H hue 0-1
+	 * @param float $S saturation 0-1
+	 * @param float $V brightness 0-1
+	 * @return array containing 3 values in the range from 0-255, R,G,B
+	 */
+	public static function HSV_TO_RGB($H, $S, $V) {
+		$H *= 6;
+		$I = floor($H);
+		$F = $H - $I;
+		$M = $V * (1 - $S);
+		$N = $V * (1 - $S * $F);
+		$K = $V * (1 - $S * (1 - $F));
+		switch ($I) {
+			case 0:
+				list($R,$G,$B) = array($V,$K,$M);
+				break;
+			case 1:
+				list($R,$G,$B) = array($N,$V,$M);
+				break;
+			case 2:
+				list($R,$G,$B) = array($M,$V,$K);
+				break;
+			case 3:
+				list($R,$G,$B) = array($M,$N,$V);
+				break;
+			case 4:
+				list($R,$G,$B) = array($K,$M,$V);
+				break;
+			case 5:
+			case 6: //for when $H=1 is given
+				list($R,$G,$B) = array($V,$M,$N);
+				break;
+		}
+		return array($R * 255.0, $G * 255.0, $B * 255.0);
+	}
+
+	/**
+	 * Convert a hex string to separate R,G,B values
+	 * @param string $hex
+	 * @return array containing 3 integers (0-255) R,G,B
+	 */
+	public static function HEX_TO_RGB($hex){
+		$RGB = array();
+
+		$color = intval(ltrim($hex, '#'), 16);
+		$r = ($color >> 16) & 0xff;
+		$g = ($color >> 8) & 0xff;
+		$b = $color & 0xff;
+
+		$RGB[] = $r;
+		$RGB[] = $g;
+		$RGB[] = $b;
+
+		return $RGB;
+	}
+
+	/**
+	 * Convert R,G,B to hex
+	 * @param int $R
+	 * @param int $G
+	 * @param int $B
+	 * @return string
+	 */
+	public static function RGB_TO_HEX($R, $G, $B){
+		return sprintf("%06X", ($R << 16) | ($G << 8) | $B);
+	}
+
+	/**
+	 * Calculate luminance (Photometric/digital ITU-R)
+	 * @param int $R
+	 * @param int $G
+	 * @param int $B
+	 * @return number 0-1
+	 */
+	public static function RGB_TO_LUMINANCE($R, $G, $B){
+		return min(1, max(0, 0.2126 * ($R / 255) + 0.7152 * ($G / 255) + 0.0722 * ($B / 255)));
+	}
+
+	public function __construct($name = null, $options = array()) {
+		parent::__construct($name, 6, $options);
+	}
+
+	public function scaffoldFormField($title = null, $params = null) {
+		$field = new ColorField($this->name, $title);
+		return $field;
+	}
+
+	/**
+	 * Get the red component of this color
+	 * @return int red-component 0-255
+	 */
+	public function Red(){
+		list($R, $G, $B) = self::HEX_TO_RGB($this->value);
+		return $R;
+	}
+
+	/**
+	 * Get the green component of this color
+	 * @return int green-component 0-255
+	 */
+	public function Green(){
+		list($R, $G, $B) = self::HEX_TO_RGB($this->value);
+		return $G;
+	}
+
+	/**
+	 * Get the blue component of this color
+	 * @return int blue-component 0-255
+	 */
+	public function Blue(){
+		list($R, $G, $B) = self::HEX_TO_RGB($this->value);
+		return $B;
+	}
+
+	/**
+	 * Get the color as CSS3 color definition with optional alpha value.
+	 * Will return "rgba(RED, GREEN, BLUE, OPACITY)"
+	 * @param number $opacity opacity value from 0-1
+	 * @return string css3 color definition
+	 */
+	public function CSSColor($opacity = 1){
+		list($R, $G, $B) = self::HEX_TO_RGB($this->value);
+		$A = self::clamp($opacity, 0, 1);
+		return sprintf('rgba(%d,%d,%d,%f)', $R, $G, $B, $A);
+	}
+
+	/**
+	 * Return the luminance of the color
+	 * @return the luminance 0-1
+	 */
+	public function Luminance(){
+		list($R, $G, $B) = self::HEX_TO_RGB($this->value);
+		return self::RGB_TO_LUMINANCE($R, $G, $B);
+	}
+
+	/**
+	 * Change the color by the given HSV values and return a new color
+	 * @param float $hChange hue change
+	 * @param float $sChange saturation change
+	 * @param float $vChange brightness change
+	 * @return Color the new color
+	 */
+	public function AlteredColorHSV($hChange, $sChange, $vChange){
+		list($R, $G, $B) = self::HEX_TO_RGB($this->value);
+		list($H, $S, $V) = self::RGB_TO_HSV($R, $G, $B);
+		list($R, $G, $B) = self::HSV_TO_RGB(
+			self::clamp($H + $hChange, 0.0, 1.0),
+			self::clamp($S + $sChange, 0.0, 1.0),
+			self::clamp($V + $vChange, 0.0, 1.0));
+		$color = new Color();
+		$color->setValue(self::RGB_TO_HEX($R, $G, $B));
+		return $color;
+	}
+
+	private static function clamp($val, $min, $max){
+		return min($max, max($min, $val));
+	}
+}

--- a/javascript/colorfield.js
+++ b/javascript/colorfield.js
@@ -1,28 +1,29 @@
 (function($) {
-    $.entwine('ss', function($) {
-        $('.ColorPickerInput').entwine({
-            onmatch: function(e) {
-                var self=$(this);
-                
-                var picker=$(this).ColorPicker({
-                    onSubmit: function(hsb, hex, rgb) {
-                        var mid=(rgb.r+rgb.g+rgb.b)/3;
-                        var col=(mid>127 ? '#000000':'#ffffff');
-                        self.val(hex).css({color:col, backgroundColor:'#'+hex});
-                    },
-                    onBeforeShow: function() {
-                        $(this).ColorPickerSetColor(this.value);
-                    },
-                    onChange: function (hsb, hex, rgb) {
-                        var mid=(rgb.r+rgb.g+rgb.b)/3;
-                        var col=(mid>127 ? '#000000':'#ffffff');
-                        self.val(hex).css({color:col, backgroundColor:'#'+hex});
-                    }
-                });
-            },
-            onkeyup: function() {
-                $(this).ColorPickerSetColor($(this).val());
-            }
-        });
-    });
+	$.entwine('ss', function($) {
+		$('input.colorfield').entwine({
+			onmatch: function(e) {
+				var self=$(this);
+				//Calculate luminance (Photometric/digital ITU-R)
+				var calcLuminance = function(rgb){
+					return Math.min(1, Math.max(0, 0.2126 * (rgb.r / 255) + 0.7152 * (rgb.g / 255) + 0.0722 * (rgb.b / 255)));
+				};
+				var picker=$(this).ColorPicker({
+					onSubmit: function(hsb, hex, rgb) {
+						var col=(calcLuminance(rgb) > 0.5 ? '#000000':'#ffffff');
+						self.val(hex).css({color:col, backgroundColor:'#'+hex});
+					},
+					onBeforeShow: function() {
+						$(this).ColorPickerSetColor(this.value);
+					},
+					onChange: function (hsb, hex, rgb) {
+						var col=(calcLuminance(rgb)  > 0.5 ? '#000000':'#ffffff');
+						self.val(hex).css({color:col, backgroundColor:'#'+hex});
+					}
+				});
+			},
+			onkeyup: function() {
+				$(this).ColorPickerSetColor($(this).val());
+			}
+		});
+	});
 })(jQuery);


### PR DESCRIPTION
Added `Color` FieldType which allows defining a color directly in the DB config. Eg. `private static $db = array( 'MyColor' => 'Color');`

Updated read me file accordingly.
It's no longer mandatory to name the module folder _colorpicker_. Any name works now.
Cleaned up ColorField class:
- Removed the `ColorField_Disabled` class, because it's no longer needed
- Prevent rendering of html tags directly. Instead leverage the underlying mechanisms of TextField. Removed redundant attributes
- Color of the text is now based on color luminance instead of RGB-average
